### PR TITLE
Fixed Buffer Overflow in RH_RF69

### DIFF
--- a/RH_RF69.cpp
+++ b/RH_RF69.cpp
@@ -500,10 +500,12 @@ bool RH_RF69::recv (uint8_t* buf, uint8_t* len)
 	if (buf && len)
 	{
 		ATOMIC_BLOCK_START;
-		if (*len >= _bufLen)
+		if (*len > _bufLen)
 		{
 			*len = _bufLen;
-			memcpy (buf, _buf, *len);
+			if (buf >= _buf){
+				memcpy (buf, _buf, *len);
+			}
 		}
 		ATOMIC_BLOCK_END;
 	}

--- a/RH_RF69.cpp
+++ b/RH_RF69.cpp
@@ -500,9 +500,11 @@ bool RH_RF69::recv (uint8_t* buf, uint8_t* len)
 	if (buf && len)
 	{
 		ATOMIC_BLOCK_START;
-		if (*len > _bufLen)
+		if (*len >= _bufLen)
+		{
 			*len = _bufLen;
-		memcpy (buf, _buf, *len);
+			memcpy (buf, _buf, *len);
+		}
 		ATOMIC_BLOCK_END;
 	}
 	_rxBufValid = false; // Got the most recent message


### PR DESCRIPTION
Code now checks the size of the buffer coming from SPI before copying the data into the receiving buffer. This fixes a buffer overflow vulnerability where an attacker could send data larger than the buffer size.